### PR TITLE
Upgrade to Swift 6 with cross-platform CI support

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-12
     steps:
       - name: git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: docbuild
         run: >
           xcodebuild docbuild -scheme DataStore \

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -2,16 +2,16 @@ name: macOS
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+    branches: ["**"]
 
 jobs:
   build:
     runs-on: macos-latest
-
     steps:
-    - uses: actions/checkout@v3
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: 16.0
+    - uses: actions/checkout@v4
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,20 @@
+name: Ubuntu
+
+on:
+  push:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: '6.1.0'
+      - uses: actions/checkout@v4
+      - name: Build for release
+        run: swift build -v -c release
+      - name: Test
+        run: swift test -v

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,21 @@
+name: Windows
+
+on:
+  push:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Swift 6.1
+        uses: compnerd/gha-setup-swift@main
+        with:
+          branch: swift-6.1-release
+          tag: 6.1-RELEASE
+
+      - run: swift --version
+      - run: swift build
+      - run: swift test

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -9,22 +9,19 @@ let package = Package(
         .macOS(.v10_15),
         .iOS(.v13),
         .watchOS(.v6),
-        .tvOS(.v13)
+        .tvOS(.v13),
+        .visionOS(.v1)
     ],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "DataStore",
             targets: ["DataStore"]
         )
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-         .package(url: "https://github.com/0xLeif/Cache", from: "2.0.0")
+        .package(url: "https://github.com/0xLeif/Cache", from: "2.0.0")
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "DataStore",
             dependencies: [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # DataStore
 
+[![macOS Build](https://img.shields.io/github/actions/workflow/status/0xLeif/DataStore/macOS.yml?label=macOS&branch=main)](https://github.com/0xLeif/DataStore/actions/workflows/macOS.yml)
+[![Ubuntu Build](https://img.shields.io/github/actions/workflow/status/0xLeif/DataStore/ubuntu.yml?label=Ubuntu&branch=main)](https://github.com/0xLeif/DataStore/actions/workflows/ubuntu.yml)
+[![Windows Build](https://img.shields.io/github/actions/workflow/status/0xLeif/DataStore/windows.yml?label=Windows&branch=main)](https://github.com/0xLeif/DataStore/actions/workflows/windows.yml)
+[![License](https://img.shields.io/github/license/0xLeif/DataStore)](https://github.com/0xLeif/DataStore/blob/main/LICENSE)
+[![Version](https://img.shields.io/github/v/release/0xLeif/DataStore)](https://github.com/0xLeif/DataStore/releases)
+
 *An extendable data storage solution with built-in caching capabilities.*
+
+## Requirements
+
+- **iOS**: 13.0+
+- **watchOS**: 6.0+
+- **macOS**: 10.15+
+- **tvOS**: 13.0+
+- **visionOS**: 1.0+
+- **Swift**: 6.0+
 
 ## What is DataStore?
 
@@ -13,6 +28,7 @@
 - **Flexible Data Retrieval**: Access loaded data via the `fetch()` method or fetch data based on specific criteria using closure-based filtering.
 - **Data Storage**: Store new data objects into the `DataStore` for later retrieval.
 - **Data Deletion**: Remove previously stored data objects from the `DataStore`.
+- **Cross-Platform**: Supports macOS, iOS, watchOS, tvOS, visionOS, Ubuntu, and Windows.
 
 ## Installation
 

--- a/Sources/DataStore/ConsumingObservableObject.swift
+++ b/Sources/DataStore/ConsumingObservableObject.swift
@@ -1,12 +1,16 @@
 #if canImport(Combine)
 import Combine
+import Foundation
 
 /// An `ObservableObject` that can consume and observe changes in other `ObservableObject` instances.
 open class ConsumingObservableObject: ObservableObject, @unchecked Sendable {
+    private let bagLock = NSLock()
     private var bag: Set<AnyCancellable> = Set()
 
     deinit {
+        bagLock.lock()
         bag.removeAll()
+        bagLock.unlock()
     }
 
     public init() { }
@@ -17,6 +21,8 @@ open class ConsumingObservableObject: ObservableObject, @unchecked Sendable {
     public func consume<Object: ObservableObject>(
         object: Object
     ) where ObjectWillChangePublisher == ObservableObjectPublisher {
+        bagLock.lock()
+        defer { bagLock.unlock() }
         bag.insert(
             object.objectWillChange.sink(
                 receiveCompletion: { _ in },

--- a/Sources/DataStore/ConsumingObservableObject.swift
+++ b/Sources/DataStore/ConsumingObservableObject.swift
@@ -2,7 +2,7 @@
 import Combine
 
 /// An `ObservableObject` that can consume and observe changes in other `ObservableObject` instances.
-open class ConsumingObservableObject: ObservableObject {
+open class ConsumingObservableObject: ObservableObject, @unchecked Sendable {
     private var bag: Set<AnyCancellable> = Set()
 
     deinit {

--- a/Sources/DataStore/DataStore.swift
+++ b/Sources/DataStore/DataStore.swift
@@ -16,7 +16,11 @@ import Cache
  - SeeAlso: `Identifiable`
  - SeeAlso: `Cache`
  */
+#if canImport(Combine)
 open class DataStore<DataLoader: DataLoading>: ConsumingObservableObject, DataStoring where DataLoader.DeviceData.To == DataLoader.DeviceData.StoredValue {
+#else
+open class DataStore<DataLoader: DataLoading>: DataStoring, @unchecked Sendable where DataLoader.DeviceData.To == DataLoader.DeviceData.StoredValue {
+#endif
 
     /// A typealias that represents the type of data loaded by the DataLoader.
     public typealias LoadedData = DataLoader.LoadedData
@@ -47,10 +51,12 @@ open class DataStore<DataLoader: DataLoading>: ConsumingObservableObject, DataSt
     ) {
         self.cache = Cache(initialValues: initalValues)
         self.loader = loader
-        
+
+        #if canImport(Combine)
         super.init()
-        
+
         consume(object: cache)
+        #endif
     }
 
     /**
@@ -108,7 +114,7 @@ open class DataStore<DataLoader: DataLoading>: ConsumingObservableObject, DataSt
 
      - Note: This method filters the fetched data using the given filter closure and returns the filtered results.
      */
-    open func fetch(where filter: (DeviceData) -> Bool) async -> [DeviceData] {
+    open func fetch(where filter: @Sendable (DeviceData) -> Bool) async -> [DeviceData] {
         let allValues = await fetch()
 
         let filteredValues = allValues.filter(filter)

--- a/Sources/DataStore/Protocols/DataLoading.swift
+++ b/Sources/DataStore/Protocols/DataLoading.swift
@@ -1,5 +1,5 @@
 /// A protocol for loading data asynchronously and adapting it to a desired format using the `Adaptable` protocol.
-public protocol DataLoading {
+public protocol DataLoading: Sendable {
     /// The type of loaded data, which should conform to the `Identifiable` protocol.
     associatedtype LoadedData: Identifiable
 

--- a/Sources/DataStore/Protocols/DataStoring.swift
+++ b/Sources/DataStore/Protocols/DataStoring.swift
@@ -21,7 +21,7 @@ public protocol DataStoring {
     /// Fetches stored `DeviceData` objects that satisfy the given filter predicate.
     /// - Parameter where: A closure that takes a `DeviceData` object and returns a Boolean value indicating whether the object should be included in the result.
     /// - Returns: An array of fetched device-specific data that pass the filter.
-    func fetch(where filter: (DeviceData) -> Bool) async -> [DeviceData]
+    func fetch(where filter: @Sendable (DeviceData) -> Bool) async -> [DeviceData]
 
     /// Fetches a single stored `DeviceData` object based on its identifier.
     /// - Parameter id: The identifier of the data to fetch.

--- a/Tests/DataStoreTests/DataStoreTests.swift
+++ b/Tests/DataStoreTests/DataStoreTests.swift
@@ -1,4 +1,3 @@
-import SwiftUI
 import XCTest
 @testable import DataStore
 
@@ -31,7 +30,7 @@ final class DataStoreTests: XCTestCase {
         try await store.load()
 
         let values = await store.fetch { data in
-            data.color == Color(red: 0, green: 1, blue: 0)
+            data.color == TestColor(red: 0, green: 1, blue: 0)
         }
 
         XCTAssertEqual(values.count, 1)
@@ -46,7 +45,7 @@ final class DataStoreTests: XCTestCase {
 
         let expectedID = UUID().uuidString
         let expectedUserName = "test"
-        let expectedColor = Color.green
+        let expectedColor = TestColor.green
         let expectedEnumValue = TestDeviceData.DeviceEnum.weirdCaseExample
 
         try await store.store(

--- a/Tests/DataStoreTests/TestObjects.swift
+++ b/Tests/DataStoreTests/TestObjects.swift
@@ -1,16 +1,31 @@
 import DataStore
+
+#if canImport(SwiftUI)
 import SwiftUI
+#endif
+
+// MARK: - TestColor
+
+/// A cross-platform color representation for testing.
+struct TestColor: Equatable, Sendable {
+    let red: Double
+    let green: Double
+    let blue: Double
+
+    static let clear = TestColor(red: 0, green: 0, blue: 0)
+    static let green = TestColor(red: 0, green: 1, blue: 0)
+}
 
 // MARK: - TestLoadedData
 
-struct TestLoadedData: Identifiable {
-    struct LoadedColor {
+struct TestLoadedData: Identifiable, Sendable {
+    struct LoadedColor: Sendable {
         let red: Double
         let green: Double
         let blue: Double
     }
 
-    enum LoadedEnum: String {
+    enum LoadedEnum: String, Sendable {
         case WeirdCaseExample
         case inconsistent_example
     }
@@ -23,8 +38,8 @@ struct TestLoadedData: Identifiable {
 
 // MARK: - TestDeviceData
 
-struct TestDeviceData: OnDeviceData {
-    enum DeviceEnum: String, Adaptable {
+struct TestDeviceData: OnDeviceData, Sendable {
+    enum DeviceEnum: String, Adaptable, Sendable {
         case weirdCaseExample
         case inconsistentExample
 
@@ -40,10 +55,10 @@ struct TestDeviceData: OnDeviceData {
 
     let id: String
     var userName: String
-    var color: Color
+    var color: TestColor
     var enumValue: DeviceEnum
 
-    init(id: String, userName: String, color: Color, enumValue: DeviceEnum) {
+    init(id: String, userName: String, color: TestColor, enumValue: DeviceEnum) {
         self.id = id
         self.userName = userName
         self.color = color
@@ -54,7 +69,7 @@ struct TestDeviceData: OnDeviceData {
         self.init(
             id: from.id,
             userName: from.user_name,
-            color: Color(
+            color: TestColor(
                 red: from.color.red,
                 green: from.color.green,
                 blue: from.color.blue
@@ -75,10 +90,10 @@ struct TestDeviceData: OnDeviceData {
 
 // MARK: - StoredData
 
-struct TestStoredData: StorableData {
+struct TestStoredData: StorableData, Sendable {
     let id: String
     let userName: String
-    let color: Color
+    let color: TestColor
     let enumValue: TestDeviceData.DeviceEnum
 
     init(from: TestDeviceData) {
@@ -91,7 +106,7 @@ struct TestStoredData: StorableData {
 
 // MARK: - TestDataLoader
 
-class TestDataLoader: DataLoading {
+final class TestDataLoader: DataLoading, Sendable {
     typealias LoadedData = TestLoadedData
     typealias DeviceData = TestDeviceData
 


### PR DESCRIPTION
## Summary

- Upgrade `swift-tools-version` from 5.6 to 6.0 with full strict concurrency compliance
- Add `visionOS(.v1)` platform support
- Add Ubuntu and Windows CI workflows (matching the pattern from Cache/AppState), addressing cross-platform support
- Update macOS CI workflow with Xcode 16 setup and trigger on all branches
- Update all `actions/checkout` from v3 to v4
- Add CI status badges, license badge, and version badge to README

### Swift 6 Concurrency Changes

- Add `@unchecked Sendable` to `ConsumingObservableObject`
- Add `Sendable` requirement to `DataLoading` protocol
- Add `@Sendable` annotation to `fetch(where:)` filter closure in both `DataStoring` protocol and `DataStore` implementation
- Conditionalize `Combine`/`ObservableObject` inheritance using `#if canImport(Combine)` so `DataStore` compiles on Linux and Windows
- Add `Sendable` conformance to all test types

### Cross-Platform Test Support

- Replace `SwiftUI.Color` usage in tests with a cross-platform `TestColor` struct
- Make `TestDataLoader` a `final class` conforming to `Sendable`

Closes #4

## Test plan

- [ ] Verify macOS CI passes (swift build + swift test)
- [ ] Verify Ubuntu CI passes (swift build + swift test)
- [ ] Verify Windows CI passes (swift build + swift test)
- [ ] Verify existing tests still pass on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)